### PR TITLE
latke-demo 的 pom.xml 上缺少对 jetty 插件的声明，需改善。

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 将项目导入 IDE，通过 `mvn install` 编译后有两种方式启动：
 
 1. `mvn jetty:run`
-2. 运行 Starter 
+2. `java -cp "target/latke-demo-2.0.0/WEB-INF/lib/*;target/latke-demo-2.0.0/WEB-INF/classes" latke.demo.Starter` （运行 Starter）
 
 打开浏览器访问 `http://localhost:8080`。
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <jetty.version>9.4.12.v20180830</jetty.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.source>12</maven.compiler.source>
     </properties>
 
     <dependencies>
@@ -53,7 +53,27 @@
         </dependency>
 
     </dependencies>
-
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <configuration>
+                    <httpConnector>
+                        <port>8080</port>
+                    </httpConnector>
+                    <stopKey>stop</stopKey>
+                    <stopPort>4501</stopPort>
+                    <webAppConfig>
+                        <contextPath>/</contextPath>
+                    </webAppConfig>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
     <profiles>
         <profile>
             <id>ci</id>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <jetty.version>9.4.12.v20180830</jetty.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>12</maven.compiler.target>
-        <maven.compiler.source>12</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## 1. pom.xml 文件里缺少下面 jetty 插件的声明
用`mvn jetty:run`命令会报错。
* 在pom.xml 文件里`</dependencies>`和`<profiles>`之间加上下面这段即可。
```
<build>
        <plugins>
            <plugin>
                <groupId>org.eclipse.jetty</groupId>
                <artifactId>jetty-maven-plugin</artifactId>
                <version>${jetty.version}</version>
                <configuration>
                    <httpConnector>
                        <port>8080</port>
                    </httpConnector>
                    <stopKey>stop</stopKey>
                    <stopPort>4501</stopPort>
                    <webAppConfig>
                        <contextPath>/</contextPath>
                    </webAppConfig>
                </configuration>
            </plugin>
        </plugins>
    </build>
```
## 2. README文件中补充对运行Starter的详细命令。